### PR TITLE
Incremental cleanup and fix for Maxscale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: ruby
-
 sudo: true
-
-# test
 
 services:
   - docker
@@ -15,10 +12,11 @@ addons:
       - apt-transport-https
 
 before_install:
-  - curl -O https://packages.chef.io/files/stable/chefdk/2.4.17/ubuntu/16.04/chefdk_2.4.17-1_amd64.deb
-  - sudo dpkg -i chefdk_2.4.17-1_amd64.deb
+  - curl -o chefdk_current.deb https://packages.chef.io/files/stable/chefdk/3.0.36/ubuntu/16.04/chefdk_3.0.36-1_amd64.deb
+  - sudo dpkg -i chefdk_current.deb
+  - sudo apt-get install -f
 install:
-  - /opt/chefdk/bin/chef gem install test-kitchen kitchen-docker kitchen-salt
+  - /opt/chefdk/bin/bundle install
 
 before_script:
   - sudo iptables -L DOCKER || sudo iptables -N DOCKER

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,8 @@ addons:
       - git
       - apt-transport-https
 
-before_install:
-  - curl -o chefdk_current.deb https://packages.chef.io/files/stable/chefdk/3.0.36/ubuntu/16.04/chefdk_3.0.36-1_amd64.deb
-
-install:
-  - sudo dpkg -i chefdk_current.deb
-  - sudo apt-get install -f
-
 before_script:
   - sudo iptables -L DOCKER || sudo iptables -N DOCKER
 
 script:
-  - /opt/chefdk/bin/chef exec kitchen verify
+  - bundle exec kitchen verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,13 @@ addons:
 
 before_install:
   - curl -o chefdk_current.deb https://packages.chef.io/files/stable/chefdk/3.0.36/ubuntu/16.04/chefdk_3.0.36-1_amd64.deb
+
+install:
   - sudo dpkg -i chefdk_current.deb
   - sudo apt-get install -f
-install:
-  - /opt/chefdk/bin/bundle install
 
 before_script:
   - sudo iptables -L DOCKER || sudo iptables -N DOCKER
-
 
 script:
   - /opt/chefdk/bin/chef exec kitchen verify

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'test-kitchen'
+gem 'kitchen-salt'
+gem 'kitchen-docker'
+

--- a/maxscale/install.sls
+++ b/maxscale/install.sls
@@ -18,8 +18,7 @@ mariadb_repo:
     - humanname: MariaDB Repository
     - name: "{{ maxscale.repo_url|replace("[[osfullname]]",salt['grains.get']('osfullname', 'ubuntu')|lower)|replace("[[oscodename]]", salt['grains.get']('oscodename', trusty)) }}"
     - file: /etc/apt/sources.list.d/mariadb.list
-    - keyid: 1BB943DB
-    - keyserver: keyserver.ubuntu.com
+    - key_url: {{ maxscale.gpg_key }}
 {%- elif os_family == 'RedHat' %}
     - humanname: {{ maxscale.humanname }}
     - baseurl: {{ maxscale.baseurl }}

--- a/maxscale/map.jinja
+++ b/maxscale/map.jinja
@@ -1,7 +1,7 @@
 {% set maxscale = salt['grains.filter_by']( {
     'Debian': {
         'etcdir': '/etc',
-        'gpgkeys': ['8167EE24', 'E3C94F49', '1BB943DB', 'C74CD1D8'],
+	'gpg_key': 'http://downloads.mariadb.com/MaxScale/MariaDB-MaxScale-GPG-KEY',
         'repo_url': 'deb http://downloads.mariadb.com/MaxScale/2.1/[[osfullname]] [[oscodename]] main',
         'pkgname': 'maxscale',
     },
@@ -11,6 +11,6 @@
         'baseurl': 'https://downloads.mariadb.com/MaxScale/2.1/rhel/$releasever/$basearch',
         'humanname': 'mariadb',
         'pkgname': 'maxscale',
-        'gpg_key': 'https://downloads.mariadb.com/MaxScale/MariaDB-MaxScale-GPG-KEY',
+        'gpg_key': 'http://downloads.mariadb.com/MaxScale/MariaDB-MaxScale-GPG-KEY',
     },
 }, grain='os_family', merge=salt['pillar.get']('maxscale', {}), default='Debian') %}

--- a/maxscale/templates/maxscale.cnf.jinja
+++ b/maxscale/templates/maxscale.cnf.jinja
@@ -1,12 +1,12 @@
 {% set maxscale = pillar.get('maxscale', {}) -%}
-{% set reserved_keys = ['service', 'service', 'server', 'listener', 'filter'] %}
+{% set reserved_keys = ['service', 'server', 'listener', 'filter'] %}
 {% set special_format_fields = ['servers', 'filters'] -%}
 
 {%- for reserved_section in reserved_keys -%}
-{%- for section, options in maxscale.get(reserved_section,{}).iteritems() %}
-{%- if options is mapping%}
+{%- for section, options in maxscale.get(reserved_section,{}).items() %}
+{%- if options is mapping %}
 [{{ section }}]
-{%- for option, value in options.iteritems() %}
+{%- for option, value in options.items() %}
 {%- if ( option == 'filters' ) %}
 {{ option }}={%- for filtername in value %}{{ filtername }}{%- if not loop.last %}|{%- endif %}{%- endfor %}
 {%- elif ( option == 'servers' ) %}
@@ -17,6 +17,4 @@
 {%- endfor %}
 {%- endif %}
 {%- endfor %}
-
-
 {%- endfor %}

--- a/maxscale/templates/maxscale.cnf.jinja
+++ b/maxscale/templates/maxscale.cnf.jinja
@@ -2,14 +2,9 @@
 {% set reserved_keys = ['service', 'service', 'server', 'listener', 'filter'] %}
 {% set special_format_fields = ['servers', 'filters'] -%}
 
-[maxscale]
-{%- for option, value in maxscale.get('config',{}).iteritems() %}
-{{option }}={{ value }}
-{%- endfor %}
-
 {%- for reserved_section in reserved_keys -%}
 {%- for section, options in maxscale.get(reserved_section,{}).iteritems() %}
-{%- if options is mapping %}
+{%- if options is mapping%}
 [{{ section }}]
 {%- for option, value in options.iteritems() %}
 {%- if ( option == 'filters' ) %}

--- a/pillar.example
+++ b/pillar.example
@@ -17,7 +17,7 @@ maxscale:
       user: maxscale
       passwd: crappyfoo
       version_string: 5.7-MariaDB-maxscale
-      wightby: serv_weight
+      weightby: serv_weight
   server:
     server1:
       address: 127.0.0.1

--- a/pillar.example
+++ b/pillar.example
@@ -36,7 +36,8 @@ maxscale:
     QLA:
       type: filter
       module: qlafilter
+      filebase: /tmp/maxscale-qlafilter.log
     counter:
       type: filter
       module: topfilter
-      filebase: /tmp/SqlQueryLog
+      filebase: /tmp/maxscale-topfilter.log

--- a/pillar.example
+++ b/pillar.example
@@ -36,6 +36,7 @@ maxscale:
     QLA:
       type: filter
       module: qlafilter
+      filebase: /tmp/SqlQueryLog
     counter:
       type: filter
       module: topfilter

--- a/pillar.example
+++ b/pillar.example
@@ -36,8 +36,7 @@ maxscale:
     QLA:
       type: filter
       module: qlafilter
-      filebase: /tmp/SqlQueryLog
     counter:
       type: filter
       module: topfilter
-
+      filebase: /tmp/SqlQueryLog

--- a/pillar.example
+++ b/pillar.example
@@ -20,6 +20,7 @@ maxscale:
       weightby: serv_weight
   server:
     server1:
+      type: server
       address: 127.0.0.1
       port: 3306
       protocol: MySQLBackend


### PR DESCRIPTION
* adds travis fixes to make testing easier
* removes dependencies on chefdk
* changes GPG key for Debian-based installs
* fixing spelling mistakes in example pillar (used for tests)
* fixed duplicate reserved words keys in maxscale.cnf template
