### PR TITLE
Changing default URL to the latest version for the packages.

### DIFF
--- a/maxscale/map.jinja
+++ b/maxscale/map.jinja
@@ -2,13 +2,13 @@
     'Debian': {
         'etcdir': '/etc',
 	'gpg_key': 'http://downloads.mariadb.com/MaxScale/MariaDB-MaxScale-GPG-KEY',
-        'repo_url': 'deb http://downloads.mariadb.com/MaxScale/2.1/[[osfullname]] [[oscodename]] main',
+        'repo_url': 'deb http://downloads.mariadb.com/MaxScale/latest/[[osfullname]] [[oscodename]] main',
         'pkgname': 'maxscale',
     },
     'RedHat': {
         'etcdir': '/etc',
         'name': 'mariadb-maxscale',
-        'baseurl': 'https://downloads.mariadb.com/MaxScale/2.1/rhel/$releasever/$basearch',
+        'baseurl': 'https://downloads.mariadb.com/MaxScale/latest/rhel/$releasever/$basearch',
         'humanname': 'mariadb',
         'pkgname': 'maxscale',
         'gpg_key': 'http://downloads.mariadb.com/MaxScale/MariaDB-MaxScale-GPG-KEY',


### PR DESCRIPTION
Updating to use `/latest` from MaxScale upstream repo.